### PR TITLE
oop-3 fix-1

### DIFF
--- a/Hybrid Models with Fine Tunnigs/DenseNet121/OOP-3/DenseNetHybridModelFunctions_3.py
+++ b/Hybrid Models with Fine Tunnigs/DenseNet121/OOP-3/DenseNetHybridModelFunctions_3.py
@@ -115,20 +115,6 @@ class DenseNetHybridModel:
             num_classes,
         )
 
-        base_model = DenseNet121(
-            weights="imagenet", include_top=False, input_shape=input_shape
-        )
-        x = base_model.output
-        x = GlobalAveragePooling2D()(x)
-        x = Dense(1024, activation="relu")(x)
-        x = Dropout(0.5)(x)
-        predictions = Dense(num_classes, activation="softmax")(x)
-        model = Model(inputs=base_model.input, outputs=predictions)
-        for layer in base_model.layers:
-            layer.trainable = False
-
-        return model
-
     # ~ create_densenet121_model DenseNet121'i bir taban model olarak kullanarak,
     # ~ belirli bir sınıflandırma problemi için uygun olacak şekilde
     # ~ özelleştirilmiş bir sinir ağı modeli oluşturur. Eklenen yeni katmanlarla birlikte,


### PR DESCRIPTION
DenseNetHybridModelFunctions_3.py sınıfında "create_densenet121_model" fonksiyonunun içerisinde olması gerekirken yanlışlıkla hemen üzerinde, kullanılmayacak şekilde yazılı olarak kalmış kod bloğu silindi.